### PR TITLE
Update for Gatsby v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "cross-env": "^5.1.4"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
The plugin appears to be working fine in Gatsby v3. This commit eliminates the following error message:

```
Plugin gatsby-plugin-portal is not compatible with your gatsby version 3.7.2 - It requires gatsby@^2.0.0
```