### PR TITLE
adds Gatsby 3 and 4 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "cross-env": "^5.1.4"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
Tested this plugin on Gatsby 3 and 4 and it works, but it keeps giving warnings about incompatibility:

`Plugin gatsby-plugin-portal is not compatible with your gatsby version 4.12.1 - It requires gatsby@^2.0.0`

This commit fixes that warning.